### PR TITLE
Using window.localStorage so it works with jsdom

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 
-let storage = localStorage // eslint-disable-line
+let storage = window.localStorage // eslint-disable-line
 
 // Authentication
 let options = {


### PR DESCRIPTION
In our tests on projects using sails-jwt, we've seen that, on node environments using jsdom, localStorage without any reference to the window causes an error :+1: