### PR TITLE
Support IE

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "presets": [ "latest" ],
   "plugins": [
     "transform-export-extensions",
     "async-to-promises"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 1.0.4
+Use `babel-preset-latest` for browser compatibility.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-jwt",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "SmartProcure's JWT NPM package.",
   "author": "SmartProcure",
   "license": "MIT",


### PR DESCRIPTION
Without using this preset, it won't run in the browser because it uses things like `let` and `async`/`await`. UglifyJS will also not be able to uglify this lib without these changes.