### PR TITLE
Enforce lower case on emails for the login method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.0.9
+﻿# 1.0.10
+Enforce lowercased email values in the AuthModel.login method
+
+# 1.0.9
 If there's an exception, only handle JWT errors if the exception
 message is a known error.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-jwt",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "SmartProcure's JWT NPM package.",
   "author": "SmartProcure",
   "license": "MIT",

--- a/server/AuthModel.js
+++ b/server/AuthModel.js
@@ -31,7 +31,7 @@ module.exports = (username = 'email', password = 'password') => {
         )
     },
     login: findOne => async (email, password) => {
-      let auth = await findOne({ email })
+      let auth = await findOne({ email: email.toLowerCase().trim() })
       if (!auth)
         return { error: 404, message: 'Incorrect email.' }
       let valid = await checkPassword(auth, password)


### PR DESCRIPTION
While slightly opinionated, most use cases support the idea of emails being case insensitive.