### PR TITLE
Convert to promises to avoid regenerator runtime errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.1.1
+# 1.1.2
+Switch from `async` to `Promise` methods to avoid regenerator runtime issues.
+
+# 1.1.1
 Making sure generateVerifyToken works after the changes on JWT.issue.
 
 # 1.1.0

--- a/client/index.js
+++ b/client/index.js
@@ -23,24 +23,17 @@ let logout = () => setToken('')
 // let addAuth = require('sp-jwt').addAuth
 // let request = _.curryN(3, addAuth(transport))
 let addAuth = f => (method, url, params, includeJwr) => {
-  if (_.isArray(params)) {
+  if (_.isArray(params))
     throw new Error(
       'Passing an array in the services will prevent auth from being added'
     )
-  }
 
   return Promise.resolve()
     .then(() => f(method, url, _.defaults({token: getToken()}, params), true))
     .then(([result, jwr]) => {
-      if (options.checkError(result, jwr)) {
-        options.handleJWTError(result, jwr)
-      }
-
+      if (options.checkError(result, jwr)) options.handleJWTError(result, jwr)
       var newToken = _.get(['headers', 'Renewed-Token'], jwr)
-      if (newToken) {
-        setToken(newToken)
-      }
-
+      if (newToken) setToken(newToken)
       return includeJwr ? [result, jwr] : result
     })
     .catch(e => {

--- a/client/index.js
+++ b/client/index.js
@@ -7,34 +7,46 @@ let options = {
   reAuthStates: /^(jwt (expired|malformed)|invalid token|concurrent login)|(No Authorization header was found)$/,
   handleJWTError: _.noop
 }
-options.checkError = (result, jwr) => (result.status === 'error' || jwr.error) && options.reAuthStates.test(result.message || result.error)
+options.checkError = (result, jwr) =>
+  (result.status === 'error' || jwr.error) &&
+  options.reAuthStates.test(result.message || result.error)
 
 // Use local storage unless it is disabled
 let token
-let setToken = newToken => { storage ? storage.setItem('jwt', newToken) : token = newToken }
-let getToken = () => storage ? storage.getItem('jwt') : token
+let setToken = newToken => {
+  storage ? storage.setItem('jwt', newToken) : (token = newToken)
+}
+let getToken = () => (storage ? storage.getItem('jwt') : token)
 let logout = () => setToken('')
 
 // Usage:
 // let addAuth = require('sp-jwt').addAuth
 // let request = _.curryN(3, addAuth(transport))
-let addAuth = f => async (method, url, params, includeJwr) => {
+let addAuth = f => (method, url, params, includeJwr) => {
   if (_.isArray(params)) {
-    throw new Error('Passing an array in the services will prevent auth from being added')
+    throw new Error(
+      'Passing an array in the services will prevent auth from being added'
+    )
   }
 
-  try {
-    let [result, jwr] = await f(method, url, _.defaults({ token: getToken() }, params), true)
-    if (options.checkError(result, jwr)) { options.handleJWTError(result, jwr) }
+  return Promise.resolve()
+    .then(() => f(method, url, _.defaults({token: getToken()}, params), true))
+    .then(([result, jwr]) => {
+      if (options.checkError(result, jwr)) {
+        options.handleJWTError(result, jwr)
+      }
 
-    var newToken = _.get(['headers', 'Renewed-Token'], jwr)
-    if (newToken) { setToken(newToken) }
+      var newToken = _.get(['headers', 'Renewed-Token'], jwr)
+      if (newToken) {
+        setToken(newToken)
+      }
 
-    return includeJwr ? [result, jwr] : result
-  } catch(e) {
-    if (options.checkError(e, {error:true})) options.handleJWTError(e)
-    throw e
-  }
+      return includeJwr ? [result, jwr] : result
+    })
+    .catch(e => {
+      if (options.checkError(e, {error: true})) options.handleJWTError(e)
+      throw e
+    })
 }
 
 export default {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-jwt",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "SmartProcure's JWT NPM package.",
   "author": "SmartProcure",
   "license": "MIT",


### PR DESCRIPTION
We can't have async errors if we don't use async :D