### PR TITLE
Port basic auth policy from SP main app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.4.0
+Add basic auth policy
+
 # 1.3.0
 Add opt-in impersonation policies
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "license": "MIT",
   "scripts": {
     "build": "webpack --config client.webpack.config.js",
-    "test": "standard src/**/*.js",
+    "test": "jest",
     "lint": "standard src/**/*.js",
     "prepublish": "npm run build",
     "start": "node server.js"
   },
   "dependencies": {
+    "basic-auth": "^1.1.0",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.0",
     "futil-js": "^1.25.0",
@@ -31,6 +32,7 @@
     "babel-plugin-async-to-promises": "^1.0.5",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
+    "jest": "^20.0.4",
     "standard": "^10.0.2",
     "webpack": "^2.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "basic-auth": "^1.1.0",
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.0",
-    "futil-js": "^1.25.0",
+    "futil-js": "^1.27.0",
     "include-all": "^4.0.3",
     "jsonwebtoken": "^7.3.0",
     "lodash": "^4.17.4",

--- a/server/__test__/basicAuthStatic.spec.js
+++ b/server/__test__/basicAuthStatic.spec.js
@@ -1,0 +1,61 @@
+const basicStaticAuth = require('../basicAuthStatic')
+
+let staticAuths = {
+  username: 'user',
+  password: 'pass',
+  model: {
+    '*': {
+      username: 'user',
+      password: 'pass'
+    },
+    method: {
+      username: 'user',
+      password: 'pass',
+    }
+  }
+}
+
+let basicAuth = basicStaticAuth(staticAuths)
+
+// basic auth user/pass
+let defaultCredentialBasicAuthHeader = 'Basic dXNlcjpwYXNz'
+
+let checkAuth = (req, res, success, auth) => {
+  basicAuth(req, res, success)
+  expect(success).toHaveBeenCalled()
+  expect(res.send).toHaveBeenCalledTimes(0)
+  success.mockClear()
+  res.send.mockClear()
+  // check that invalid credentials fail
+  auth.username = ''
+  auth.password = ''
+  basicAuth(req, res, success)
+  expect(res.send).toHaveBeenCalledWith(401, 'Basic Auth Failed')
+  expect(success).toHaveBeenCalledTimes(0)
+  success.mockClear()
+  res.send.mockClear()
+}
+
+it('Should Check Basic Auth', async () => {
+  let req = {
+    originalUrl: '/some/url',
+    headers: {
+      authorization: defaultCredentialBasicAuthHeader
+    }
+  }
+
+  let res = {
+    send: jest.fn()
+  }
+
+  let success = jest.fn()
+
+  // Global user/pass auth
+  checkAuth(req, res, success, staticAuths)
+  // Controller basic auth
+  req.originalUrl = '/model/test'
+  checkAuth(req, res, success, staticAuths.model['*'])
+  // Controller method basic auth
+  req.originalUrl = '/model/method'
+  checkAuth(req, res, success, staticAuths.model.method)
+})

--- a/server/basicAuthStatic.js
+++ b/server/basicAuthStatic.js
@@ -1,0 +1,42 @@
+const _ = require('lodash/fp')
+const reduce = _.reduce.convert({cap: false})
+const find = _.find.convert({cap: false})
+const basicAuth = require('basic-auth')
+
+// Reads auths format from config:
+// Example config:
+// var localjs = {
+//     staticAuths: {
+//         username: 'defaultUser',
+//         password: 'defaultPass',
+//         controller:     { username: 'user', password: 'pass' },
+//         controller2:    {
+//             '*':            { username: 'user', password: 'pass' },
+//             other:          { username: 'usr2', password: 'pas2' },
+//             openMethod:     true,
+//             lockedMethod:   false
+//         }
+//     }
+// }
+
+let getAuth = (url, auths) => {
+  if (!url) return false
+
+  let parts = url.substr(1).split('/');
+  return reduce((memo, part) => {
+    return find((val, key) => {
+      return (new RegExp('^' + part + '$', 'i')).test(key);
+    }, memo) || memo['*'] || memo;
+  }, auths, parts)
+}
+
+module.exports = staticAuths => (req, res, next) => {
+  let credentials = basicAuth(req)
+  let auth = getAuth(req.originalUrl, staticAuths);
+
+  let result = (auth !== false) && ((auth === true) || (credentials && credentials.name === auth.username && credentials.pass === auth.password));
+  if (result)
+    next();
+  else
+    res.send(401, 'Basic Auth Failed');
+}


### PR DESCRIPTION
Adding basic auth policy to sails-jwt so that it can be used to implement basic auth endpoints in the marketplace app