### PR TITLE
Clean up basicAuthStatic implementation

### DIFF
--- a/__test__/basicAuthStatic.spec.js
+++ b/__test__/basicAuthStatic.spec.js
@@ -1,16 +1,16 @@
 const basicStaticAuth = require('../server/basicAuthStatic')
 
 let staticAuths = {
-  username: 'user',
-  password: 'pass',
+  name: 'user',
+  pass: 'pass',
   model: {
     '*': {
-      username: 'user',
-      password: 'pass'
+      name: 'user',
+      pass: 'pass'
     },
     method: {
-      username: 'user',
-      password: 'pass',
+      name: 'user',
+      pass: 'pass',
     }
   }
 }

--- a/server/basicAuthStatic.js
+++ b/server/basicAuthStatic.js
@@ -20,7 +20,7 @@ const basicAuth = require('basic-auth')
 // }
 
 let urlParts = x => (x || '').substr(1).split('/')
-let caselessEqual = (part, key) => f.makeAndTest('i')(`^${part}$`)(key)
+let caselessEqual = (a, b) => RegExp(`^${a}$`, 'i').test(b)
 let getAuth = (auths, url) =>
   f.reduce(
     (memo, part) =>

--- a/server/basicAuthStatic.js
+++ b/server/basicAuthStatic.js
@@ -33,11 +33,7 @@ module.exports = staticAuths => (req, res, next) => {
   let credentials = basicAuth(req)
   let auth = getAuth(req.originalUrl, f.callOrReturn(staticAuths))
 
-  let result = _.isBoolean(auth)
-    ? auth
-    : credentials &&
-      credentials.name === auth.username &&
-      credentials.pass === auth.password
+  let result = _.isBoolean(auth) ? auth : _.isEqual(credentials, auth)
 
   if (result) next()
   else res.send(401, 'Basic Auth Failed')


### PR DESCRIPTION
Based on PR feedback in #17

Renames basic auth static config to name/pass instead of username/password to simplify the implementation.