### PR TITLE
Fixing duplicated responses on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 1.4.6
+﻿# 1.4.7
+Bug fix for `login` which was calling to res.send even though it was a
+wrapped in a sails-async method.
+
+ # 1.4.6
 Bug fix for `stripToken` which wasn't stripping the token if you pass an empty string
 
 # 1.4.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-jwt",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "SmartProcure's JWT NPM package.",
   "author": "SmartProcure",
   "license": "MIT",

--- a/server/AuthController.js
+++ b/server/AuthController.js
@@ -1,12 +1,15 @@
 let _ = require('lodash/fp')
 let JWT = require('./JWT')
 let {method} = require('sails-async')
+let F = require('futil-js')
 
 module.exports = {
   login: (login, username='email', password='password', id='id') => method(async (req, res) => {
     let user = await login(req.param(username), req.param(password))
-    if (user.error)
-      return res.status(user.error || 401).send(user)
+    if (user.error) {
+      if (user.error) F.throws(user.error)
+      return 401
+    }
     let token = JWT.issue({
       user: user[id]
     })


### PR DESCRIPTION
Bug fix for `login` which was calling to res.send even though it was a wrapped in a sails-async `method`.