### PR TITLE
Returning 401 instead of using res.send

### DIFF
--- a/server/basicAuthStatic.js
+++ b/server/basicAuthStatic.js
@@ -27,5 +27,5 @@ module.exports = staticAuths => (req, res, next) => {
 
   let result = (auth !== false) && ((auth === true) || (credentials && credentials.name === auth.username && credentials.pass === auth.password));
   if (result) next()
-  else res.send(401, 'Basic Auth Failed')
+  else return 401
 }


### PR DESCRIPTION
This will make the `Cannot write to response more than once` error go away.