### PR TITLE
Throwing the error message on a failed login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿# 1.4.7
+﻿# 1.4.8
+Making sure `login` throws the error message instead of just the
+status code if there's a message.
+
+# 1.4.7
 Bug fix for `login` which was calling to res.send even though it was a
 wrapped in a sails-async method.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-jwt",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "SmartProcure's JWT NPM package.",
   "author": "SmartProcure",
   "license": "MIT",

--- a/server/AuthController.js
+++ b/server/AuthController.js
@@ -7,7 +7,7 @@ module.exports = {
   login: (login, username='email', password='password', id='id') => method(async (req, res) => {
     let user = await login(req.param(username), req.param(password))
     if (user.error) {
-      if (user.error) F.throws(user.error)
+      if (user.error) F.throws(user.message || user.error)
       return 401
     }
     let token = JWT.issue({


### PR DESCRIPTION
This is necessary for our architecture, otherwise the message is lost.