### PR TITLE
Fixing res.send issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+﻿# 2.0.3
+Fixed issue with res.send
+
 # 2.0.2
 Switching to F.reduceIndexed since F.reduce is deprecated
 

--- a/__test__/basicAuthStatic.spec.js
+++ b/__test__/basicAuthStatic.spec.js
@@ -30,7 +30,7 @@ let checkAuth = (req, res, success, auth) => {
   auth.username = ''
   auth.password = ''
   basicAuth(req, res, success)
-  expect(res.send).toHaveBeenCalledWith(401, 'Basic Auth Failed')
+  expect(res.send).toHaveBeenCalledWith('Basic Auth Failed')
   expect(success).toHaveBeenCalledTimes(0)
   success.mockClear()
   res.send.mockClear()
@@ -45,8 +45,9 @@ it('Should Check Basic Auth', async () => {
   }
 
   let res = {
-    send: jest.fn()
+    send: jest.fn(),
   }
+  res.status = () => ({ send: res.send })
 
   let success = jest.fn()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-jwt",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "SmartProcure's JWT NPM package.",
   "author": "SmartProcure",
   "license": "MIT",

--- a/server/basicAuthStatic.js
+++ b/server/basicAuthStatic.js
@@ -27,5 +27,5 @@ module.exports = staticAuths => (req, res, next) => {
 
   let result = (auth !== false) && ((auth === true) || (credentials && credentials.name === auth.username && credentials.pass === auth.password));
   if (result) next()
-  else res.send(401, 'Basic Auth Failed')
+  else res.status(401).send('Basic Auth Failed')
 }


### PR DESCRIPTION
It was showing an error on console because `res.send(401...` is deprecated.